### PR TITLE
Bump deepomatic client to v0.7.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 opencv-python==3.4.3.18
 Pillow==5.3.0
 progressbar2==3.38.0
-git+https://github.com/deepomatic/deepomatic-client-python@v0.7.5#egg=deepomatic-0.7.5
+git+https://github.com/deepomatic/deepomatic-client-python@v0.7.6#egg=deepomatic-0.7.6


### PR DESCRIPTION
The inference with the encoding parameter will raise an error from the API if we don't update the python client.

